### PR TITLE
Add permlink functionality to lexicon

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,12 @@ module.exports = {
       options: {
         plugins: [
           {
+            resolve: 'gatsby-remark-autolink-headers',
+            options: {
+              offsetY: 70
+            }
+          },
+          {
             resolve: 'gatsby-remark-graph',
             options: {
               // this is the language in your code-block that triggers mermaid parsing

--- a/package-lock.json
+++ b/package-lock.json
@@ -5759,6 +5759,25 @@
         "warning": "^3.0.0"
       }
     },
+    "gatsby-remark-autolink-headers": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.3.tgz",
+      "integrity": "sha512-pMce69OrUnUKf/QALBw8MxMYG+aBuLR/Sh2Q3178Gb6KIk7q0TR/UAO7djqnuQqgrZKtyWe9lqxDXkciIrLD1w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "github-slugger": "^1.1.1",
+        "lodash": "^4.17.14",
+        "mdast-util-to-string": "^1.0.2",
+        "unist-util-visit": "^1.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
     "gatsby-remark-graph": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/gatsby-remark-graph/-/gatsby-remark-graph-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-plugin-google-gtag": "^1.0.16",
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-plugin-twitter": "^2.0.13",
+    "gatsby-remark-autolink-headers": "^2.1.3",
     "gatsby-remark-graph": "^0.2.2",
     "gatsby-source-filesystem": "^2.0.28",
     "gatsby-transformer-remark": "^2.3.12",

--- a/src/components/alphabetSlider.js
+++ b/src/components/alphabetSlider.js
@@ -3,25 +3,11 @@ import AlphabethSliderStyle from "./alphabetSlider.module.css";
 
 const chars = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
-const navigateTo = (char) => (event) => {
-  const element = event.target;
-  // get surrounding element
-  const referenceElement = element.parentElement.parentElement;
-  const target = Array.from(referenceElement.querySelectorAll('h1'))
-    .find(item => item.innerText.trim() === char);
-  const targetTop = target.offsetTop;
-  window.scrollTo({
-    top: targetTop - 70,
-    left: 0,
-    behavior: 'auto'
-  });
-};
-
 export default (props) => {
   return (
     <div className={AlphabethSliderStyle.container}>
       {chars.map(char => (
-        <div className={AlphabethSliderStyle.char} key={char} onClick={navigateTo(char)}>{char}</div>
+        <a className={AlphabethSliderStyle.char} key={char} href={'#' + char.toLowerCase()} >{char}</a>
       ))}
     </div>
   )

--- a/src/components/alphabetSlider.module.css
+++ b/src/components/alphabetSlider.module.css
@@ -13,6 +13,11 @@
   box-sizing: border-box;
 }
 
+.container a {
+  color: #000;
+  text-decoration: none;
+}
+
 .char {
   display: flex;
   align-items: flex-end;
@@ -22,9 +27,10 @@
   line-height: 20px;
 }
 
-.char:hover {
+.char:not(.inactive):hover {
   font-weight: bold;
   font-size: 20px;
+  color: #000;
 }
 
 @media only screen and (max-height: 650px) {

--- a/src/pages/lexicon.module.css
+++ b/src/pages/lexicon.module.css
@@ -1,10 +1,21 @@
 .lexicon-container {
   max-width: 700px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .lexicon-container h1, 
 .lexicon-container h2 {
   text-align: center;
+  display: flex;
+  align-items: center;
+}
+
+.lexicon-container h1 a, 
+.lexicon-container h2 a {
+  display: flex;
+  align-items: center;
 }
 
 .lexicon-container h1 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,7 +5,6 @@ html, body {
     font-family: 'Fira Sans', sans-serif;
     position: relative;
     width: 100%;
-    height: 100%;
     margin: 0;
     padding: 0;
     display: flex;


### PR DESCRIPTION
Closes #53 
Permanent Links to lexicon entries can be for a complete section e.g. #e or for entries like #airdrop there are icons on the left which can be used to jump to the direct link and copy it from the url bar of the browser