### PR TITLE
Lexicon Style Fix

### DIFF
--- a/src/pages/lexicon.module.css
+++ b/src/pages/lexicon.module.css
@@ -14,14 +14,15 @@
   border-radius: 5px;
   position: absolute;
   left: 0;
-  margin-top: 25px;
+  bottom: 10px;
 }
 
 .lexicon-container h1, 
 .lexicon-container h2 {
-  text-align: center;
   display: flex;
-  align-items: center;
+  position: relative;
+  width: 100%;
+  justify-content: center;
 }
 
 .lexicon-container h1 a, 


### PR DESCRIPTION
On mobile (especially iOS Safari) the header underline was overlaying the header text itself. With this change the line should be at correct position for desktop and mobile