### PR TITLE
Feature/timeline without article

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,32 +6,37 @@ exports.createPages = ({ actions, graphql }) => {
   const blogPostTemplate = path.resolve(`src/templates/blogTemplate.js`)
 
   return graphql(`
-    {
-      allMarkdownRemark(
-        filter: {frontmatter: {path: {regex: "/(^\/timeline|^\/log)/" }}}
-        sort: { order: DESC, fields: [frontmatter___date] }
-        limit: 1000
-      ) {
-        edges {
-          node {
-            frontmatter {
-              path
-            }
+  {
+    allMarkdownRemark(
+      filter: {
+        fileAbsolutePath: {
+          regex: "/\/timeline|\/log/"
+        }
+      },
+      sort: { order: DESC, fields: [frontmatter___date] }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            path
           }
         }
       }
     }
+  }
   `).then(result => {
     if (result.errors) {
       return Promise.reject(result.errors)
     }
 
     result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-      createPage({
-        path: node.frontmatter.path,
-        component: blogPostTemplate,
-        context: {}, // additional data can be passed via context
-      })
+      if (node.frontmatter.path) {
+        createPage({
+          path: node.frontmatter.path,
+          component: blogPostTemplate,
+          context: {}, // additional data can be passed via context
+        })
+      }
     })
   })
 }

--- a/src/components/alphabetSlider.module.css
+++ b/src/components/alphabetSlider.module.css
@@ -9,7 +9,7 @@
   height: 100%;
   top: 0;
   margin:0;
-  padding: 70px 0;
+  padding: 80px 0 40px 0;
   box-sizing: border-box;
 }
 
@@ -35,7 +35,7 @@
 
 @media only screen and (max-width: 710px) {
   .container {
-    padding: 50px 0;
+    padding: 60px 0 30px 0;
   }
 }
 
@@ -67,7 +67,7 @@
   }
 
   .scrolled {
-    box-shadow: 0 5px 5px rgba(0,0,0,0.25), 0 2px 2px rgba(0,0,0,0.22);
+    box-shadow: 0 6px 5px rgba(0,0,0,0.25), 0 3px 2px rgba(0,0,0,0.22);
   }
 
   .char {

--- a/src/components/timelineItem.js
+++ b/src/components/timelineItem.js
@@ -14,8 +14,12 @@ export default (props) => {
     )
   } else {
     const itemData = props.data.frontmatter;
+    let className = timelineItem.container;
+    if (itemData.path) {
+      className = `${className} ${timelineItem.interactive}`;
+    }
     return (
-      <div className={timelineItem.container + ' ' + props.className}
+      <div className={className + ' ' + props.className}
         onClick={() => openURL(itemData.path)}>
         {itemData.thumbnail ? (
           <div className={timelineItem.thumbnailContainer}>

--- a/src/components/timelineItem.js
+++ b/src/components/timelineItem.js
@@ -2,36 +2,43 @@ import React from "react";
 import { dateFormatter, openURL } from "../utils/common.util";
 import timelineItem from "./timelineItem.module.css";
 
+const renderFirst = (itemClasses) => (
+  <div className={itemClasses}>
+    <div className={timelineItem.icon}><i className="fas fa-calendar-day"></i></div>
+    <div className={timelineItem.titleSmall}>{'Today: ' + dateFormatter(new Date())}</div>
+    <div className={timelineItem.line}></div>
+  </div>
+)
+
+const renderItem = (itemData, itemClasses) => (
+  <div className={itemClasses}
+    onClick={() => openURL(itemData.path)}>
+    {itemData.thumbnail ? (
+      <div className={timelineItem.thumbnailContainer}>
+        <img className={timelineItem.thumbnail} src={itemData.thumbnail} alt="" />
+        <div className={timelineItem.thumbnailSource}>Image: {itemData.thumbnailSource}</div>
+      </div>
+    ) : ""}
+    <div className={timelineItem.icon}><i className={itemData.icon || "fas fa-bell"}></i></div>
+    <div className={timelineItem.date}>{dateFormatter(itemData.date)}</div>
+    <div className={timelineItem.title}>{itemData.title}</div>
+    <div className={timelineItem.line}></div>
+  </div>
+)
 
 export default (props) => {
+  let className = `${timelineItem.container} ${props.className}`;
   if (props.isFirst) {
-    return (
-      <div className={timelineItem.container + ' ' + timelineItem.first + ' ' + props.className}
-        title={'Today: ' + dateFormatter(new Date())}>
-        <div className={timelineItem.icon}><i className="fas fa-calendar-day"></i></div>
-        <div className={timelineItem.line}></div>
-      </div>
-    )
+    className = `${className} ${timelineItem.first}`;
+    return renderFirst(className);
   } else {
     const itemData = props.data.frontmatter;
-    let className = timelineItem.container;
     if (itemData.path) {
       className = `${className} ${timelineItem.interactive}`;
     }
-    return (
-      <div className={className + ' ' + props.className}
-        onClick={() => openURL(itemData.path)}>
-        {itemData.thumbnail ? (
-          <div className={timelineItem.thumbnailContainer}>
-            <img className={timelineItem.thumbnail} src={itemData.thumbnail} alt="" />
-            <div className={timelineItem.thumbnailSource}>Image: {itemData.thumbnailSource}</div>
-          </div>
-        ) : ""}
-        <div className={timelineItem.icon}><i className={itemData.icon || "fas fa-bell"}></i></div>
-        <div className={timelineItem.date}>{dateFormatter(itemData.date)}</div>
-        <div className={timelineItem.title}>{itemData.title}</div>
-        <div className={timelineItem.line}></div>
-      </div>
-    )
+    if (!itemData.thumbnail) {
+      className = `${className} ${timelineItem.small}`;
+    }
+    return renderItem(itemData, className);
   }
 }

--- a/src/components/timelineItem.module.css
+++ b/src/components/timelineItem.module.css
@@ -8,10 +8,13 @@
   border-radius: 5px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+}
+
+.interactive {
   cursor: pointer;
 }
 
-.container:hover {
+.interactive:hover {
   box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
 }
 

--- a/src/components/timelineItem.module.css
+++ b/src/components/timelineItem.module.css
@@ -10,14 +10,6 @@
   transition: all 0.3s cubic-bezier(.25,.8,.25,1);
 }
 
-.interactive {
-  cursor: pointer;
-}
-
-.interactive:hover {
-  box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
-}
-
 .container:nth-child(odd) {
   margin-left: 300px;
   margin-right: 0;
@@ -25,6 +17,21 @@
 
 .container.first {
   box-shadow: none;
+  height: 80px;
+}
+
+.small {
+  height: auto;
+  box-shadow: none;
+}
+
+.interactive {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  cursor: pointer;
+}
+
+.interactive:hover {
+  box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
 }
 
 .thumbnail-container {
@@ -105,18 +112,22 @@
   font-size: 20px;
 }
 
+.title-small {
+  font-size: 15px;
+}
+
 @media only screen and (max-width: 700px) {
   .container:nth-child(odd),
   .container {
     margin-left: 0;
     margin-right: 0;
-    margin-top: 5px;
+    margin-top: 10px;
   }
 
   .container:nth-child(odd) .line,
   .container .line {
     left: -31px;
-    height: calc(100% + 5px);
+    height: calc(100% + 10px);
   }
   
   .container:nth-child(odd) .icon,

--- a/src/data/log/2019-03-31-how-to-contribute.md
+++ b/src/data/log/2019-03-31-how-to-contribute.md
@@ -46,7 +46,9 @@ thumbnailSource: "where you got the image from"
 ```
 
 The date should contain the release date of the article. The title is the name which is displayed in the main section and the path is the URL to reach the article. The path should match the following pattern:
-- `timeline/[filename]`
+- `timeline/[filename]`  
+
+The `path` is an optional parameter. If you do not specify a path you can create a timeline item without content. So the item is not clickable. We will only show the event as part of the timeline but not attach an article to it.
 
 The icon can be any fontawesome icon name and will be displayed in the timeline. The default icon is:
 - `fas fa-bell`

--- a/src/pages/log.js
+++ b/src/pages/log.js
@@ -18,7 +18,11 @@ export default ({ data }) => (
 export const query = graphql`
   query {
     allMarkdownRemark(
-      filter: {frontmatter: {path: {regex: "/^\/log/" }}}
+      filter: {
+        fileAbsolutePath: {
+          regex: "/\/log/"
+        }
+      },
       sort: { order: DESC, fields: [frontmatter___publishedOn] }
     ) {
       edges {

--- a/src/pages/timeline.js
+++ b/src/pages/timeline.js
@@ -21,7 +21,11 @@ export default ({ data }) => (
 export const query = graphql`
   query {
     allMarkdownRemark(
-      filter: {frontmatter: {path: {regex: "/^\/timeline/" }}}
+      filter: {
+        fileAbsolutePath: {
+          regex: "/\/timeline/"
+        }
+      },
       sort: { order: DESC, fields: [frontmatter___date] }
     ) {
       edges {


### PR DESCRIPTION
Lexicon improvements:
- alphabetSlider on side has now even better space usage on mobile screens  

Some Timeline Optimizations:
- Timeline "Today"-Date is now always visible at the top
- Updated "How to contribute to timeline" to cover Timeline-Only Items without attached Article. This is determined based on the `path` attribute
- Optimize Timeline space usage
- If no path and no thumbnail is provided the Timeline-Item has no shadow border